### PR TITLE
Add missing include

### DIFF
--- a/copy_in_here_GNL_files/GNL_TESTS.h
+++ b/copy_in_here_GNL_files/GNL_TESTS.h
@@ -15,6 +15,7 @@
 
 # include <assert.h>
 # include <stdio.h>
+# include <stdlib.h>
 # include <fcntl.h>
 # include <sys/stat.h>
 # include <unistd.h>


### PR DESCRIPTION
Hello,
There are some errors when compiling with my Get_Next_Line because stdlib.h is missing in the main files.
The script complains that free is not defined.
Here is a small fix for the problem!